### PR TITLE
Integrate RabbitMQ for Messaging between reviewms and companyms

### DIFF
--- a/companyms/Dockerfile
+++ b/companyms/Dockerfile
@@ -1,0 +1,14 @@
+# Use the official OpenJDK 17 image as a base
+FROM openjdk:17-jdk
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Adjust the path if the jar file is in a different location
+COPY target/jobcompanyreview-0.0.1-SNAPSHOT.jar app.jar
+
+# Expose the port that your application will run on
+EXPOSE 8080
+
+# Run the JAR file
+CMD ["java", "-jar", "app.jar"]

--- a/companyms/docker-compose.yml
+++ b/companyms/docker-compose.yml
@@ -35,7 +35,35 @@ services:
     image: openzipkin/zipkin
     container_name: zipkin
     ports:
-      - 9411:9411
+      - "9411:9411"
+    networks:
+      - postgres
+    restart: unless-stopped
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - postgres
+    restart: unless-stopped
+
+  # Uncomment and configure the 'app' service if needed
+  # app:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile
+  #   image: jobcompanyreview-app
+  #   container_name: jobcompanyreview_container
+  #   ports:
+  #     - "8080:8080"
+  #   networks:
+  #     - postgres
+  #   depends_on:
+  #     - postgres
+  #   restart: unless-stopped
 
 networks:
   postgres:

--- a/companyms/pom.xml
+++ b/companyms/pom.xml
@@ -67,6 +67,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/companyms/src/main/java/com/mansoor/companyms/CompanymsApplication.java
+++ b/companyms/src/main/java/com/mansoor/companyms/CompanymsApplication.java
@@ -2,8 +2,10 @@ package com.mansoor.companyms;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class CompanymsApplication {
 
 	public static void main(String[] args) {

--- a/companyms/src/main/java/com/mansoor/companyms/company/Company.java
+++ b/companyms/src/main/java/com/mansoor/companyms/company/Company.java
@@ -2,6 +2,7 @@ package com.mansoor.companyms.company;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
+
 import java.util.List;
 
 @Entity
@@ -11,6 +12,7 @@ public class Company {
     private Long id;
     private String name;
     private String description;
+    private Double rating;
 
     public Company() {
 
@@ -39,4 +41,13 @@ public class Company {
     public void setDescription(String description) {
         this.description = description;
     }
+
+    public Double getRating() {
+        return rating;
+    }
+
+    public void setRating(Double rating) {
+        this.rating = rating;
+    }
+
 }

--- a/companyms/src/main/java/com/mansoor/companyms/company/CompanyService.java
+++ b/companyms/src/main/java/com/mansoor/companyms/company/CompanyService.java
@@ -1,5 +1,7 @@
 package com.mansoor.companyms.company;
 
+import com.mansoor.companyms.company.dto.ReviewMessage;
+
 import java.util.List;
 
 public interface CompanyService {
@@ -13,4 +15,6 @@ public interface CompanyService {
     boolean deleteCompanyById(Long id);
 
     Company getCompanyById(Long id);
+
+    public void updateCompanyRating(ReviewMessage reviewMessage);
 }

--- a/companyms/src/main/java/com/mansoor/companyms/company/clients/ReviewClient.java
+++ b/companyms/src/main/java/com/mansoor/companyms/company/clients/ReviewClient.java
@@ -1,0 +1,13 @@
+package com.mansoor.companyms.company.clients;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient("REVIEW-SERVICE")
+public interface ReviewClient {
+
+    @GetMapping("/api/v1/reviews/averageRating")
+    Double getAverageRatingForCompany(@RequestParam("companyId") Long companyId);
+
+}

--- a/companyms/src/main/java/com/mansoor/companyms/company/dto/ReviewMessage.java
+++ b/companyms/src/main/java/com/mansoor/companyms/company/dto/ReviewMessage.java
@@ -1,0 +1,50 @@
+package com.mansoor.companyms.company.dto;
+
+public class ReviewMessage {
+    private Long id;
+    private String title;
+    private String description;
+    private double rating;
+    private Long companyId;
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public double getRating() {
+        return rating;
+    }
+
+    public void setRating(double rating) {
+        this.rating = rating;
+    }
+
+    public Long getCompanyId() {
+        return companyId;
+    }
+
+    public void setCompanyId(Long companyId) {
+        this.companyId = companyId;
+    }
+}

--- a/companyms/src/main/java/com/mansoor/companyms/company/impl/CompanyServiceImpl.java
+++ b/companyms/src/main/java/com/mansoor/companyms/company/impl/CompanyServiceImpl.java
@@ -4,6 +4,9 @@ package com.mansoor.companyms.company.impl;
 import com.mansoor.companyms.company.Company;
 import com.mansoor.companyms.company.CompanyRepository;
 import com.mansoor.companyms.company.CompanyService;
+import com.mansoor.companyms.company.clients.ReviewClient;
+import com.mansoor.companyms.company.dto.ReviewMessage;
+import jakarta.ws.rs.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,9 +16,11 @@ import java.util.Optional;
 public class CompanyServiceImpl implements CompanyService {
 
     private final CompanyRepository companyRepository;
+    private final ReviewClient reviewClient;
 
-    public CompanyServiceImpl(CompanyRepository companyRepository) {
+    public CompanyServiceImpl(CompanyRepository companyRepository, ReviewClient reviewClient) {
         this.companyRepository = companyRepository;
+        this.reviewClient = reviewClient;
     }
 
     @Override
@@ -56,5 +61,16 @@ public class CompanyServiceImpl implements CompanyService {
     @Override
     public Company getCompanyById(Long id) {
         return companyRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public void updateCompanyRating(ReviewMessage reviewMessage) {
+
+        System.out.println(reviewMessage.getDescription());
+        Company company = companyRepository.findById(reviewMessage.getCompanyId()).orElseThrow(() -> new NotFoundException("Company Not Found" + reviewMessage.getCompanyId()));
+
+        double averageRating = reviewClient.getAverageRatingForCompany(reviewMessage.getCompanyId());
+        company.setRating(averageRating);
+        companyRepository.save(company);
     }
 }

--- a/companyms/src/main/java/com/mansoor/companyms/company/messaging/RabbitMQConfiguration.java
+++ b/companyms/src/main/java/com/mansoor/companyms/company/messaging/RabbitMQConfiguration.java
@@ -1,0 +1,31 @@
+package com.mansoor.companyms.company.messaging;
+
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfiguration {
+    @Bean
+    Queue companyRatingQueue() {
+        return new Queue("Company Rating Queue");
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(final ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate =
+                new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jsonMessageConverter());
+        return rabbitTemplate;
+    }
+}

--- a/companyms/src/main/java/com/mansoor/companyms/company/messaging/ReviewMessageConsumer.java
+++ b/companyms/src/main/java/com/mansoor/companyms/company/messaging/ReviewMessageConsumer.java
@@ -1,0 +1,20 @@
+package com.mansoor.companyms.company.messaging;
+
+import com.mansoor.companyms.company.CompanyService;
+import com.mansoor.companyms.company.dto.ReviewMessage;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReviewMessageConsumer {
+    private final CompanyService companyService;
+
+    public ReviewMessageConsumer(CompanyService companyService) {
+        this.companyService = companyService;
+    }
+
+    @RabbitListener(queues = "CompanyRatingQueue")  // Ensure queue name matches
+    public void consumeMessage(ReviewMessage reviewMessage) {
+        companyService.updateCompanyRating(reviewMessage);
+    }
+}

--- a/companyms/src/main/resources/application.properties
+++ b/companyms/src/main/resources/application.properties
@@ -18,5 +18,26 @@ management.tracing.sampling.probability=1.0
 #management.zipkin.tracing.endpoint=9411
 
 
+# RabbitMQ connection settings
+spring.rabbitmq.host=localhost
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=guest
+spring.rabbitmq.password=guest
+
+## Optional settings
+#spring.rabbitmq.virtual-host=/
+#spring.rabbitmq.connection-timeout=30000
+#spring.rabbitmq.requested-heartbeat=30
+#spring.rabbitmq.listener.simple.retry.enabled=true
+#spring.rabbitmq.listener.simple.retry.max-attempts=3
+#spring.rabbitmq.listener.simple.retry.initial-interval=5000
+#spring.rabbitmq.listener.simple.retry.multiplier=1.5
+#spring.rabbitmq.listener.simple.retry.max-interval=10000
+#
+## Additional configurations for RabbitMQ
+#spring.rabbitmq.publisher.confirm=true
+#spring.rabbitmq.publisher.timeout=10000
+
+
 
 

--- a/reviewms/pom.xml
+++ b/reviewms/pom.xml
@@ -67,6 +67,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/reviewms/src/main/java/com/mansoor/reviewms/review/ReviewController.java
+++ b/reviewms/src/main/java/com/mansoor/reviewms/review/ReviewController.java
@@ -1,5 +1,6 @@
 package com.mansoor.reviewms.review;
 
+import com.mansoor.reviewms.review.messaging.ReviewMessageProducer;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,9 +11,11 @@ import java.util.List;
 @RequestMapping("/api/v1/reviews")
 public class ReviewController {
     private final ReviewService reviewService;
+    private final ReviewMessageProducer reviewMessageProducer;
 
-    public ReviewController(ReviewService reviewService) {
+    public ReviewController(ReviewService reviewService, ReviewMessageProducer reviewMessageProducer) {
         this.reviewService = reviewService;
+        this.reviewMessageProducer = reviewMessageProducer;
     }
 
 
@@ -25,6 +28,7 @@ public class ReviewController {
     public ResponseEntity<String> addReview(@RequestParam Long companyId, @RequestBody Review review) {
         boolean isReviewSaved = reviewService.addReview(companyId, review);
         if (isReviewSaved) {
+            reviewMessageProducer.sendMessage(review);
             return new ResponseEntity<>("Review Added Successfully", HttpStatus.OK);
         } else {
             return new ResponseEntity<>("Review Not Saved", HttpStatus.NOT_FOUND);
@@ -58,5 +62,12 @@ public class ReviewController {
             return new ResponseEntity<>("Review Not Deleted", HttpStatus.NOT_FOUND);
 
         }
+    }
+
+    @GetMapping("/averageRating")
+    public Double getAverageReview(@RequestParam Long companyId) {
+        List<Review> reviewList = reviewService.getAllReviews(companyId);
+        return reviewList.stream().mapToDouble(Review::getRating).average().orElse(0.0);
+
     }
 }

--- a/reviewms/src/main/java/com/mansoor/reviewms/review/dto/ReviewMessage.java
+++ b/reviewms/src/main/java/com/mansoor/reviewms/review/dto/ReviewMessage.java
@@ -1,0 +1,50 @@
+package com.mansoor.reviewms.review.dto;
+
+public class ReviewMessage {
+    private Long id;
+    private String title;
+    private String description;
+    private double rating;
+    private Long companyId;
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public double getRating() {
+        return rating;
+    }
+
+    public void setRating(double rating) {
+        this.rating = rating;
+    }
+
+    public Long getCompanyId() {
+        return companyId;
+    }
+
+    public void setCompanyId(Long companyId) {
+        this.companyId = companyId;
+    }
+}

--- a/reviewms/src/main/java/com/mansoor/reviewms/review/messaging/RabbitMQConfiguration.java
+++ b/reviewms/src/main/java/com/mansoor/reviewms/review/messaging/RabbitMQConfiguration.java
@@ -1,0 +1,32 @@
+package com.mansoor.reviewms.review.messaging;
+
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfiguration {
+    @Bean
+    Queue companyRatingQueue() {
+        return new Queue("CompanyRatingQueue");
+    }
+
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(final ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate =
+                new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jsonMessageConverter());
+        return rabbitTemplate;
+    }
+}

--- a/reviewms/src/main/java/com/mansoor/reviewms/review/messaging/ReviewMessageProducer.java
+++ b/reviewms/src/main/java/com/mansoor/reviewms/review/messaging/ReviewMessageProducer.java
@@ -1,0 +1,29 @@
+package com.mansoor.reviewms.review.messaging;
+
+import com.mansoor.reviewms.review.Review;
+import com.mansoor.reviewms.review.dto.ReviewMessage;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReviewMessageProducer {
+    private final RabbitTemplate rabbitTemplate;
+
+    public ReviewMessageProducer(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    public void sendMessage(Review review) {
+        ReviewMessage reviewMessage = new ReviewMessage();
+
+        reviewMessage.setId(review.getId());
+        reviewMessage.setTitle(review.getTitle());
+        reviewMessage.setDescription(review.getDescription());
+        reviewMessage.setRating(review.getRating());
+        reviewMessage.setCompanyId(review.getCompanyId());
+
+        rabbitTemplate.convertAndSend("CompanyRatingQueue", reviewMessage);
+    }
+
+
+}

--- a/reviewms/src/main/resources/application.properties
+++ b/reviewms/src/main/resources/application.properties
@@ -17,3 +17,9 @@ eureka.client.fetch-registry=true
 management.tracing.sampling.probability=1.0
 
 #management.zipkin.tracing.endpoint=9411
+
+# RabbitMQ connection settings
+spring.rabbitmq.host=localhost
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=guest
+spring.rabbitmq.password=guest


### PR DESCRIPTION
**Pull Request: Merge feat/messaging-queues into develop**

This pull request merges the `feat/messaging-queues` branch into the `develop` branch, introducing RabbitMQ for messaging and queuing between the `reviewms` and `companyms` services. The following changes have been implemented:

- **RabbitMQ Producer in reviewms**: Added and configured a RabbitMQ producer to handle message publishing.
- **RabbitMQ Consumer in companyms**: Implemented and configured a RabbitMQ consumer to process incoming messages.
- **OpenFeign Integration in companyms**: Integrated OpenFeign to facilitate communication between services and handle messages received via RabbitMQ.
- **RabbitMQ Configuration in companyms**: Configured RabbitMQ properties and queue bindings for proper message handling in companyms.
